### PR TITLE
Fix set-remote-properties!

### DIFF
--- a/src/bacure/remote_device.clj
+++ b/src/bacure/remote_device.clj
@@ -273,12 +273,9 @@
   ([device-id write-access-specificiations]
    (set-remote-properties! nil device-id write-access-specificiations))
   ([local-device-id device-id write-access-specificiations]
-   (if (-> (ld/local-device-object local-device-id)
-           (.getRemoteDevice device-id)
-           (.getServicesSupported)
-           c/bacnet->clojure
+   (if (-> (services-supported device-id)
            :write-property-multiple)
-     
+
      ;; normal behavior
      (let [req (WritePropertyMultipleRequest.
                 (c/clojure->bacnet :sequence-of


### PR DESCRIPTION
I'm honestly not sure why it would throw this, but it seemed to me that we might as well use the existing `services-supported` function anyway, which was working. Seems to work fine now.

(The only real change is at 276. Everything else is auto-formatting.)

```
(bc-remote/set-remote-properties! 100200 {[:analog-value 1] [[:present-value 22]]
                                                [:analog-value 2] [[:present-value 5.5]]})

IllegalArgumentException No matching field found: getServicesSupported for class com.serotonin.bacnet4j.LocalDevice$2  clojure.lang.Reflector.getInstanceField (Reflector.java:271)
```
