### PR TITLE
Add configurable wait

### DIFF
--- a/src/bacure/remote_device.clj
+++ b/src/bacure/remote_device.clj
@@ -4,7 +4,8 @@
             [bacure.local-device :as ld]
             [bacure.read-properties :as rp]
             [bacure.services :as services]
-            [bacure.events :as events])
+            [bacure.events :as events]
+            [bacure.util :as util])
   (:import (com.serotonin.bacnet4j RemoteDevice
                                    event.DeviceEventAdapter
                                    service.confirmed.CreateObjectRequest
@@ -160,7 +161,7 @@
 
   ([local-device-id object-identifier-or-name args]
    (services/send-who-has local-device-id object-identifier-or-name args)
-   (Thread/sleep 1000)
+   (util/configurable-wait args)
    (get-remote-devices-having-object local-device-id object-identifier-or-name)))
 
 (defn find-remote-devices
@@ -179,7 +180,7 @@
 
   ([local-device-id args]
    (services/send-who-is local-device-id args)
-   (Thread/sleep 1000)
+   (util/configurable-wait args)
    (events/cached-remote-devices local-device-id)))
 
 (defn find-remote-device

--- a/src/bacure/util.clj
+++ b/src/bacure/util.clj
@@ -1,5 +1,11 @@
 (ns bacure.util)
 
+(defn configurable-wait
+  [{:keys [wait-seconds]
+    :or   {wait-seconds 1}
+    :as   args}]
+
+  (Thread/sleep (* 1000 wait-seconds)))
 
 (defmacro mapify
   "Given some symbols, construct a map with the symbols as keys, and


### PR DESCRIPTION
I've been looking into an issue where, the first time after booting up that I call `find-remote-devices-having-object`, I do get an I-Have response, but the object it gives me is `nil`. Every subsequent time, you get your object, no matter what ID / name you're looking for. So I thought maybe it was a timing thing, so I added this configurability to test it out. 

Turns out it's not a timing thing, and this happens even if you wait a long time. But I figured this functionality might still be useful to someone, hence the PR.