### PR TITLE
Fix reset-local-device! always resetting every device

### DIFF
--- a/src/bacure/local_device.clj
+++ b/src/bacure/local_device.clj
@@ -321,7 +321,7 @@
   ---> reset the device and change the device id."
   ([] (reset-local-device! nil nil))
   ([config-or-id] (if (map? config-or-id)
-                    (reset-local-device! nil config-or-id)
+                    (reset-local-device! (:device-id config-or-id) config-or-id)
                     (reset-local-device! config-or-id nil)))
   ([local-device-id new-config]
    (if-not (get-local-device local-device-id)


### PR DESCRIPTION
Before this change, terminate! would get called with nil from reset-local-device!. So get-local-device would grab the first device it found instead of the intended one. 

I found this when an MSTP device was getting reset by the creation of another (IP) device. The reset was not pretty and it threw an error down in the serial implementation.

That itself might also be a separate issue...