### PR TITLE
Formatting + small refactor

### DIFF
--- a/src/bacure/coerce/type/constructed.clj
+++ b/src/bacure/coerce/type/constructed.clj
@@ -22,10 +22,10 @@
             DeviceObjectReference
             DeviceObjectPropertyReference
             EventTransitionBits
-            
+
             LimitEnable
             LogRecord
-           
+
             ObjectPropertyReference
             ObjectTypesSupported
             PriorityValue
@@ -52,17 +52,17 @@
 
 
 (defn c-access-rule [value]
-  (let [{:keys [time-range-specifier time-range location-specifier location enable] 
+  (let [{:keys [time-range-specifier time-range location-specifier location enable]
          :or {time-range-specifier :always
               time-range nil
               location-specifier :all
               location nil
               enable true}} value]
     (AccessRule. ;(clojure->bacnet :time-range-specifier time-range-specifier) ;;<- only for private constructor
-                 (clojure->bacnet :device-object-property-reference time-range)
-                 ;(clojure->bacnet :location-specifier location-specifier) ;;<- only for private constructor
-                 (clojure->bacnet :device-object-reference location)
-                 (clojure->bacnet :boolean enable))))
+     (clojure->bacnet :device-object-property-reference time-range)
+                                        ;(clojure->bacnet :location-specifier location-specifier) ;;<- only for private constructor
+     (clojure->bacnet :device-object-reference location)
+     (clojure->bacnet :boolean enable))))
 
 (defmethod clojure->bacnet :access-rule
   [_ value]
@@ -72,9 +72,9 @@
 (defmethod bacnet->clojure AccessRule
   [^AccessRule o]
   {
-   ;:time-range-specifier (bacnet->clojure (.getTimeRangeSpecifier o))
+                                        ;:time-range-specifier (bacnet->clojure (.getTimeRangeSpecifier o))
    :time-range (bacnet->clojure (.getTimeRange o))
-   ;:location-specifier (bacnet->clojure (.getLocationSpecifier o))
+                                        ;:location-specifier (bacnet->clojure (.getLocationSpecifier o))
    :location (bacnet->clojure (.getLocation o))
    :enable (bacnet->clojure (.getEnable o))})
 
@@ -141,8 +141,8 @@
 
 
 (defn c-action-list [coll]
-  (clojure->bacnet :sequence-of 
-                   (map (partial clojure->bacnet :action-command) 
+  (clojure->bacnet :sequence-of
+                   (map (partial clojure->bacnet :action-command)
                         (or coll [nil]))))
 
 (defmethod clojure->bacnet :action-list
@@ -172,7 +172,7 @@
   [^Choice o]
   (bacnet->clojure (.getDatum o)))
 
-;;; 
+;;;
 
 (defn c-daily-schedule [value]
   (DailySchedule.
@@ -181,7 +181,7 @@
 
 (defmethod clojure->bacnet :daily-schedule
   [_ value]
-  (c-daily-schedule 
+  (c-daily-schedule
    (or value [{:time "17:35:1.224" :value 10.2}])))
 
 (defmethod bacnet->clojure DailySchedule
@@ -211,13 +211,13 @@
   (let [date (.getDate o)
         time (.getTime o)]
     ;; we don't handle unspecified time for now.
-    (str (clj-time.core/date-time (.getCenturyYear date) ;; unspecified = 255   
+    (str (clj-time.core/date-time (.getCenturyYear date) ;; unspecified = 255
                                   (max (.getId (.getMonth date)) 1) ;; unspecified default to 1
                                   (let [day (.getDay date)]
                                     (if (= day com.serotonin.bacnet4j.type.primitive.Date/UNSPECIFIED_DAY)
                                       1 day)) ;; unspecified default to 1
                                   (if (.isHourUnspecified time) 0
-                                    (.getHour time))
+                                      (.getHour time))
                                   (if (.isMinuteUnspecified time) 0
                                       (.getMinute time))
                                   (if (.isSecondUnspecified time) 0
@@ -268,7 +268,7 @@
       (throw (Exception. (str "The value for "property-identifier
                               " must already be converted into a bacnet4j object."))))
     (PropertyValue. (clojure->bacnet :property-identifier property-identifier)
-                    (when property-array-index 
+                    (when property-array-index
                       (clojure->bacnet :unsigned-integer property-array-index))
                     value
                     (when priority (clojure->bacnet :unsigned-integer priority)))))
@@ -278,11 +278,11 @@
     (c-property-value* nil)
     (let [[property-identifier value] vectors]
       (c-property-value* {:property-identifier property-identifier
-                         :value value}))))
+                          :value value}))))
 
-(defn c-property-value 
+(defn c-property-value
   "Encode the property-value object. The value must already be a bacnet4j object.
-  
+
   Accept 2 forms. The simple form is the one usually returned when
   converting the bacnet4j object into a clojure datastructure.
 
@@ -294,7 +294,7 @@
 
   Or simple:
   - [property-identifier value]"[m]
-  (if (map? m) 
+  (if (map? m)
     (c-property-value* m)
     (c-simple-property-value m)))
 
@@ -303,7 +303,7 @@
   [_ m]
   (let [{:keys [object-type property-identifier value priority]
          :or {object-type :analog-input property-identifier :present-value value 0}} m
-        encoded-value (obj/encode-property-value object-type property-identifier 
+        encoded-value (obj/encode-property-value object-type property-identifier
                                                  (if (nil? value)
                                                    (obj/force-type value :null) value))]
     (c-property-value {:property-identifier property-identifier
@@ -364,7 +364,7 @@
 
 
 
-(defn c-device-object-reference 
+(defn c-device-object-reference
   [[device-identifier object-identifier]]
   (DeviceObjectReference. (clojure->bacnet :object-identifier device-identifier)
                           (clojure->bacnet :object-identifier object-identifier)))
@@ -384,7 +384,7 @@
 
 ;;;
 
-(defn c-event-transition-bits 
+(defn c-event-transition-bits
   [{:keys [to-fault to-normal to-offnormal]
     :or {to-fault false to-normal false to-offnormal false}}]
   (EventTransitionBits. to-offnormal to-fault to-normal))
@@ -489,7 +489,7 @@
               :property-array-index (bacnet->clojure (.getPropertyArrayIndex o))
               :property-identifier (bacnet->clojure (.getPropertyIdentifier o))}]
     [(:device-identifier data)
-     (-> (clojure->bacnet :object-property-reference 
+     (-> (clojure->bacnet :object-property-reference
                           [(:object-identifier data)
                            [(:property-identifier data)
                             (:property-array-index data)]])
@@ -503,11 +503,11 @@
    [<property-identifier> <property-identifier>]
    [[<property-identifier> <array-index>] [<property-identifier> <array-index>]]"
   [object-identifier property-references]
-   (ReadAccessSpecification.
-    (clojure->bacnet :object-identifier object-identifier)
-    (clojure->bacnet 
-     :sequence-of
-     (mapv (partial clojure->bacnet :property-reference) property-references))))
+  (ReadAccessSpecification.
+   (clojure->bacnet :object-identifier object-identifier)
+   (clojure->bacnet
+    :sequence-of
+    (mapv (partial clojure->bacnet :property-reference) property-references))))
 
 (defmethod clojure->bacnet :read-access-specification
   [_ value]
@@ -664,7 +664,7 @@
 ;;;
 
 (defn c-setpoint-reference [object-property-reference]
-  (SetpointReference. 
+  (SetpointReference.
    (clojure->bacnet :object-property-reference object-property-reference)))
 
 (defmethod clojure->bacnet :setpoint-reference
@@ -715,10 +715,10 @@
 
 (defmethod bacnet->clojure StatusFlags
   [^StatusFlags o]
-    {:in-alarm (.isInAlarm o)
-     :fault (.isFault o)
-     :out-of-service (.isOutOfService o)
-     :overridden (.isOverridden o)})
+  {:in-alarm (.isInAlarm o)
+   :fault (.isFault o)
+   :out-of-service (.isOutOfService o)
+   :overridden (.isOverridden o)})
 ;;;
 
 (def object-types-supported
@@ -758,7 +758,7 @@
 
 (defmethod bacnet->clojure TimeValue
   [^TimeValue o]
-  {:time (bacnet->clojure (.getTime o)) 
+  {:time (bacnet->clojure (.getTime o))
    :value (bacnet->clojure (.getValue o))})
 
 ;;;
@@ -827,7 +827,7 @@
 ;;                               (.getPropertyIdentifier prop-ref)
 ;;                               (.getPropertyArrayIndex prop-ref))))
 
-; DeviceObjectPropertyReference
+                                        ; DeviceObjectPropertyReference
 
 
 ;;;

--- a/src/bacure/coerce/type/constructed.clj
+++ b/src/bacure/coerce/type/constructed.clj
@@ -60,7 +60,7 @@
               enable true}} value]
     (AccessRule. ;(clojure->bacnet :time-range-specifier time-range-specifier) ;;<- only for private constructor
      (clojure->bacnet :device-object-property-reference time-range)
-                                        ;(clojure->bacnet :location-specifier location-specifier) ;;<- only for private constructor
+     ;;(clojure->bacnet :location-specifier location-specifier) ;;<- only for private constructor
      (clojure->bacnet :device-object-reference location)
      (clojure->bacnet :boolean enable))))
 
@@ -72,9 +72,9 @@
 (defmethod bacnet->clojure AccessRule
   [^AccessRule o]
   {
-                                        ;:time-range-specifier (bacnet->clojure (.getTimeRangeSpecifier o))
+   ;;:time-range-specifier (bacnet->clojure (.getTimeRangeSpecifier o))
    :time-range (bacnet->clojure (.getTimeRange o))
-                                        ;:location-specifier (bacnet->clojure (.getLocationSpecifier o))
+   ;;:location-specifier (bacnet->clojure (.getLocationSpecifier o))
    :location (bacnet->clojure (.getLocation o))
    :enable (bacnet->clojure (.getEnable o))})
 

--- a/src/bacure/coerce/type/constructed.clj
+++ b/src/bacure/coerce/type/constructed.clj
@@ -53,11 +53,11 @@
 
 (defn c-access-rule [value]
   (let [{:keys [time-range-specifier time-range location-specifier location enable]
-         :or {time-range-specifier :always
-              time-range nil
-              location-specifier :all
-              location nil
-              enable true}} value]
+         :or   {time-range-specifier :always
+                time-range           nil
+                location-specifier   :all
+                location             nil
+                enable               true}} value]
     (AccessRule. ;(clojure->bacnet :time-range-specifier time-range-specifier) ;;<- only for private constructor
      (clojure->bacnet :device-object-property-reference time-range)
      ;;(clojure->bacnet :location-specifier location-specifier) ;;<- only for private constructor
@@ -75,8 +75,8 @@
    ;;:time-range-specifier (bacnet->clojure (.getTimeRangeSpecifier o))
    :time-range (bacnet->clojure (.getTimeRange o))
    ;;:location-specifier (bacnet->clojure (.getLocationSpecifier o))
-   :location (bacnet->clojure (.getLocation o))
-   :enable (bacnet->clojure (.getEnable o))})
+   :location   (bacnet->clojure (.getLocation o))
+   :enable     (bacnet->clojure (.getEnable o))})
 
 ;;;
 
@@ -97,9 +97,9 @@
 
 (defmethod bacnet->clojure AccumulatorRecord
   [^AccumulatorRecord o]
-  {:timestamp (bacnet->clojure (.getTimestamp o))
-   :present-value (bacnet->clojure (.getPresentValue o))
-   :accumulated-value (bacnet->clojure (.getAccumulatedValue o))
+  {:timestamp          (bacnet->clojure (.getTimestamp o))
+   :present-value      (bacnet->clojure (.getPresentValue o))
+   :accumulated-value  (bacnet->clojure (.getAccumulatedValue o))
    :accumulator-status (bacnet->clojure (.getAccumulatorStatus o))})
 
 ;;;
@@ -127,15 +127,15 @@
 
 (defmethod bacnet->clojure ActionCommand
   [^ActionCommand o]
-  {:device-identifier (bacnet->clojure (.getDeviceIdentifier o))
-   :object-identifier (bacnet->clojure (.getObjectIdentifier o))
-   :property-identifier (bacnet->clojure (.getPropertyIdentifier o))
+  {:device-identifier    (bacnet->clojure (.getDeviceIdentifier o))
+   :object-identifier    (bacnet->clojure (.getObjectIdentifier o))
+   :property-identifier  (bacnet->clojure (.getPropertyIdentifier o))
    :property-array-index (bacnet->clojure (.getPropertyArrayIndex o))
-   :property-value (bacnet->clojure (.getPropertyValue o))
-   :priority (bacnet->clojure (.getPriority o))
-   :post-delay (bacnet->clojure (.getPostDelay o))
-   :quit-on-failure (bacnet->clojure (.getQuitOnFailure o))
-   :write-successful (bacnet->clojure (.getWriteSuccessful o))})
+   :property-value       (bacnet->clojure (.getPropertyValue o))
+   :priority             (bacnet->clojure (.getPriority o))
+   :post-delay           (bacnet->clojure (.getPostDelay o))
+   :quit-on-failure      (bacnet->clojure (.getQuitOnFailure o))
+   :write-successful     (bacnet->clojure (.getWriteSuccessful o))})
 
 ;;;
 
@@ -162,7 +162,7 @@
 
 (defmethod bacnet->clojure Address
   [^Address o]
-  {:mac-address (bacnet->clojure (.getMacAddress o))
+  {:mac-address    (bacnet->clojure (.getMacAddress o))
    :network-number (bacnet->clojure (.getNetworkNumber o))})
 
 
@@ -263,7 +263,7 @@
 
 (defn c-property-value* [m]
   (let [{:keys [property-identifier property-array-index value priority]
-         :or {value (clojure->bacnet :unsigned-integer nil)}} m] ;; <-- allow quick object generation with empty map
+         :or   {value (clojure->bacnet :unsigned-integer nil)}} m] ;; <-- allow quick object generation with empty map
     (when-not (instance? com.serotonin.bacnet4j.type.Encodable value)
       (throw (Exception. (str "The value for "property-identifier
                               " must already be converted into a bacnet4j object."))))
@@ -278,7 +278,7 @@
     (c-property-value* nil)
     (let [[property-identifier value] vectors]
       (c-property-value* {:property-identifier property-identifier
-                          :value value}))))
+                          :value               value}))))
 
 (defn c-property-value
   "Encode the property-value object. The value must already be a bacnet4j object.
@@ -302,13 +302,14 @@
 (defmethod clojure->bacnet :property-value*
   [_ m]
   (let [{:keys [object-type property-identifier value priority]
-         :or {object-type :analog-input property-identifier :present-value value 0}} m
+         :or   {object-type :analog-input property-identifier :present-value value 0}} m
+
         encoded-value (obj/encode-property-value object-type property-identifier
                                                  (if (nil? value)
                                                    (obj/force-type value :null) value))]
     (c-property-value {:property-identifier property-identifier
-                       :value encoded-value
-                       :priority priority})))
+                       :value               encoded-value
+                       :priority            priority})))
 
 
 ;; Another though one. Most of the time, users won't care about the
@@ -338,15 +339,15 @@
 
 (defmethod bacnet->clojure PropertyValue
   [^PropertyValue o]
-  (let [p-id (bacnet->clojure (.getPropertyIdentifier o))
+  (let [p-id          (bacnet->clojure (.getPropertyIdentifier o))
         p-array-index (bacnet->clojure (.getPropertyArrayIndex o))
-        value (bacnet->clojure (.getValue o))
-        priority (bacnet->clojure (.getPriority o))]
+        value         (bacnet->clojure (.getValue o))
+        priority      (bacnet->clojure (.getPriority o))]
     (if *detailed-property-value*
-      {:property-identifier p-id
+      {:property-identifier  p-id
        :property-array-index p-array-index
-       :value value
-       :priority priority}
+       :value                value
+       :priority             priority}
       [p-id value])))
 
 
@@ -395,8 +396,8 @@
 
 (defmethod bacnet->clojure EventTransitionBits
   [^EventTransitionBits o]
-  {:to-fault (.isToFault o)
-   :to-normal (.isToNormal o)
+  {:to-fault     (.isToFault o)
+   :to-normal    (.isToNormal o)
    :to-offnormal (.isToOffnormal o)})
 
 
@@ -404,7 +405,7 @@
 
 (defn c-limit-enable
   [{:keys [high-limit-enable low-limit-enable]
-    :or {high-limit-enable false low-limit-enable false}}]
+    :or   {high-limit-enable false low-limit-enable false}}]
   (LimitEnable. low-limit-enable high-limit-enable))
 
 (defmethod clojure->bacnet :limit-enable
@@ -414,7 +415,7 @@
 (defmethod bacnet->clojure LimitEnable
   [^LimitEnable o]
   {:high-limit-enable (.isHighLimitEnable o)
-   :low-limit-enable (.isLowLimitEnable o)})
+   :low-limit-enable  (.isLowLimitEnable o)})
 
 
 
@@ -434,10 +435,10 @@
 (defmethod bacnet->clojure LogRecord
   [^LogRecord o]
   (let [value (.getChoice o)]
-    {:timestamp (bacnet->clojure (.getTimestamp o))
+    {:timestamp    (bacnet->clojure (.getTimestamp o))
      :status-flags (bacnet->clojure (.getStatusFlags o))
-     :type (c/class-to-keyword (class value))
-     :value (bacnet->clojure value)}))
+     :type         (c/class-to-keyword (class value))
+     :value        (bacnet->clojure value)}))
 
 
 
@@ -484,10 +485,10 @@
 
 (defmethod bacnet->clojure DeviceObjectPropertyReference
   [^DeviceObjectPropertyReference o]
-  (let [data {:device-identifier (bacnet->clojure (.getDeviceIdentifier o))
-              :object-identifier (bacnet->clojure (.getObjectIdentifier o))
+  (let [data {:device-identifier    (bacnet->clojure (.getDeviceIdentifier o))
+              :object-identifier    (bacnet->clojure (.getObjectIdentifier o))
               :property-array-index (bacnet->clojure (.getPropertyArrayIndex o))
-              :property-identifier (bacnet->clojure (.getPropertyIdentifier o))}]
+              :property-identifier  (bacnet->clojure (.getPropertyIdentifier o))}]
     [(:device-identifier data)
      (-> (clojure->bacnet :object-property-reference
                           [(:object-identifier data)
@@ -699,14 +700,14 @@
   [^ShedLevel o]
   (or (try {:real (bacnet->clojure (.getAmount o))}
            (catch Exception e))
-      {:level (bacnet->clojure (.getLevel o))
+      {:level   (bacnet->clojure (.getLevel o))
        :percent (bacnet->clojure (.getPercent o))}))
 
 
 ;;;
 
-(defn c-status-flags [{:keys[in-alarm fault overridden out-of-service]
-                       :or {in-alarm false fault false overridden false out-of-service false}}]
+(defn c-status-flags [{:keys [in-alarm fault overridden out-of-service]
+                       :or   {in-alarm false fault false overridden false out-of-service false}}]
   (StatusFlags. in-alarm fault overridden out-of-service))
 
 (defmethod clojure->bacnet :status-flags
@@ -715,10 +716,10 @@
 
 (defmethod bacnet->clojure StatusFlags
   [^StatusFlags o]
-  {:in-alarm (.isInAlarm o)
-   :fault (.isFault o)
+  {:in-alarm       (.isInAlarm o)
+   :fault          (.isFault o)
    :out-of-service (.isOutOfService o)
-   :overridden (.isOverridden o)})
+   :overridden     (.isOverridden o)})
 ;;;
 
 (def object-types-supported
@@ -758,7 +759,7 @@
 
 (defmethod bacnet->clojure TimeValue
   [^TimeValue o]
-  {:time (bacnet->clojure (.getTime o))
+  {:time  (bacnet->clojure (.getTime o))
    :value (bacnet->clojure (.getValue o))})
 
 ;;;

--- a/src/bacure/remote_device.clj
+++ b/src/bacure/remote_device.clj
@@ -293,6 +293,8 @@
                                           (c/clojure->bacnet :unsigned-integer priority)))]
      (services/send-request-promise local-device-id device-id request))))
 
+(defn write-property-multiple-request
+  )
 
 (defn set-remote-properties!
   "Set the given remote object properties.

--- a/src/bacure/remote_device.clj
+++ b/src/bacure/remote_device.clj
@@ -299,11 +299,11 @@
   (let [req (WritePropertyMultipleRequest.
              (c/clojure->bacnet :sequence-of
                                 (map #(c/clojure->bacnet :write-access-specification %)
-                                     write-access-specificiations)))]
+                                     write-access-specifications)))]
     (services/send-request-promise local-device-id device-id req)))
 
 (defn write-single-multiple-properties
-  [local-device-id device-id write-access-specificiations]
+  [local-device-id device-id write-access-specifications]
 
   (let [set-object-props!
         (fn [[obj-id props]]
@@ -312,7 +312,7 @@
                 (assoc :object-identifier obj-id
                        :property-id prop-id
                        :property-value prop-value))))]
-    (->> (mapcat set-object-props! write-access-specificiations)
+    (->> (mapcat set-object-props! write-access-specifications)
          (remove :success)
          (#(if (seq %) {:error {:write-properties-errors (vec %)}} {:success true})))))
 
@@ -321,19 +321,19 @@
 
   Will block until we receive a response back, success or failure.
 
-  'write-access-specificiations' is a map of the form:
+  'write-access-specifications' is a map of the form:
   {[:analog-input 1] [[:present-value 10.0][:description \"short description\"]]}
 
   If the remote device doesn't support 'write-property-multiple',
   fallback to writing all properties individually."
-  ([device-id write-access-specificiations]
-   (set-remote-properties! nil device-id write-access-specificiations))
-  ([local-device-id device-id write-access-specificiations]
+  ([device-id write-access-specifications]
+   (set-remote-properties! nil device-id write-access-specifications))
+  ([local-device-id device-id write-access-specifications]
    (if (-> (services-supported device-id) :write-property-multiple)
      ;; normal behavior
-     (write-property-multiple local-device-id device-id write-access-specificiations)
+     (write-property-multiple local-device-id device-id write-access-specifications)
      ;; fallback to writing properties individually
-     (write-single-multiple-properties local-device-id device-id write-access-specificiations))))
+     (write-single-multiple-properties local-device-id device-id write-access-specifications))))
 
 ;; ;; ================================================================
 ;; ;; Maintenance of the remote devices list

--- a/src/bacure/remote_device.clj
+++ b/src/bacure/remote_device.clj
@@ -293,14 +293,20 @@
                                           (c/clojure->bacnet :unsigned-integer priority)))]
      (services/send-request-promise local-device-id device-id request))))
 
+(defn send-write-property-multiple-request
+  [local-device-id device-id bacnet-write-access-specifications]
+
+  (->> bacnet-write-access-specifications
+       (c/clojure->bacnet :sequence-of)
+       WritePropertyMultipleRequest.
+       (services/send-request-promise local-device-id device-id)))
+
 (defn write-property-multiple
   [local-device-id device-id write-access-specifications]
 
-  (let [req (WritePropertyMultipleRequest.
-             (c/clojure->bacnet :sequence-of
-                                (map #(c/clojure->bacnet :write-access-specification %)
-                                     write-access-specifications)))]
-    (services/send-request-promise local-device-id device-id req)))
+  (->> write-access-specifications
+       (map #(c/clojure->bacnet :write-access-specification %))
+       (send-write-property-multiple-request local-device-id device-id)))
 
 (defn write-single-multiple-properties
   [local-device-id device-id write-access-specifications]


### PR DESCRIPTION
Everything except the stuff around `set-remote-properties!` is just formatting.

`set-remote-properties!` is just a simple refactor. No real code or logic change. I just pulled some things out into named functions. (More composable + testable + readable)

I was originally trying to figure out how to send a more customized write-property-multiple request that would intentionally be malformed (in order to reproduce some BTL tests), but so far I've struck out. BACnet4J seems to want to only "play nice." 