### PR TITLE
Add deps.edn for Clojure deps/CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml
 .lein-plugins
 .nrepl-port
 /log
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,15 @@
+{:deps      {org.clojure/clojure             {:mvn/version "1.9.0"}
+             org.clojars.frozenlock/bacnet4j {:mvn/version "5.0.0-1"
+                                              :exclusions  [org.slf4j/slf4j-api 
+                                                            lohbihler/sero-scheduler]}
+             org.slf4j/slf4j-api             {:mvn/version "1.7.26"}
+             lohbihler/sero-scheduler        {:mvn/version "1.1.0"
+                                              :exclusions  [org.slf4j/slf4j-api]}
+             clj-serial                      {:mvn/version "2.0.5"}
+             clj-time                        {:mvn/version "0.15.0"}
+             org.slf4j/slf4j-log4j12         {:mvn/version "1.7.26"}}
+ :aliases   {:dev {:extra-paths ["dev"]}}
+ :paths     ["src"]
+ :jvm-opts  ["-Dpurejavacomm.loglevel=0"]
+ :mvn/repos {"ias-snapshots" {:url "https://maven.mangoautomation.net/repository/ias-snapshot/"}
+             "ias-releases"  {:url "https://maven.mangoautomation.net/repository/ias-release/"}}}


### PR DESCRIPTION
I've switched over to tools.deps and Clojure CLI, and I find it very useful to be able to pin dependencies on git commit hashes. But this is best done by having a deps.edn in the target dependency. So I added one for bacure. It doesn't interfere with Leiningen, but it would require updating the dependencies in both files. 

So if you don't want this, I can just maintain it separately on my fork. 